### PR TITLE
Removed single quotes from 'env'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ Next, create your environment keys:
 ```
 cp .env.example .env
 ```
-There are couple of keys you need to set in the '.env' file. The next sections will show you how you can get these keys.
+There are couple of keys you need to set in the `.env` file. The next sections will show you how you can get these keys.
 
 #### Pusher
 


### PR DESCRIPTION
Removed single quotes from 'env'  in readme file and replaced it with backticks